### PR TITLE
SWI-6558: serialize sample-app nightly via simulator lock

### DIFF
--- a/.jenkins/Jenkinsfile-Nightly
+++ b/.jenkins/Jenkinsfile-Nightly
@@ -1,5 +1,8 @@
 pipeline {
     agent any
+    options {
+        lock('ios-simulator')
+    }
     triggers {
         cron('H 0 * * *')
     }


### PR DESCRIPTION
## What
Add `options { lock('ios-simulator') }` to the nightly pipeline so only one sample-app nightly holds the iOS Simulator at a time.

## Why
All five sample-app nightlies trigger at `H 0 * * *` (midnight hour) and target the same `iPhone 17` simulator on a single macOS agent. When two overlap they contend for shared CoreSimulator / asset-compilation services, and `actool` (CompileAssetCatalogVariant) + `ibtool` (CompileStoryboard) fail with intermittent nonzero exits.

A named Jenkins lock serializes access deterministically — overlapping jobs queue on the lock instead of failing — which is more robust than time-staggering. Triggers are unchanged.

## Notes
- Requires the **Lockable Resources** plugin on the controller; the `ios-simulator` resource is auto-created on first reference.
- Resolves SWI-6558.